### PR TITLE
Ignore possibly overridden container hostname.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function(callback) {
 			});
 			return null;
 		}
-		
+
 	} else {
 		// already determined. use cache.
 		if (child_process.execSync) {
@@ -34,5 +34,6 @@ module.exports = function(callback) {
 };
 
 function determine(data) {
-	return data.match(new RegExp('[0-9]+\:[a-z_-]+\:\/docker\/' + hostname + '[0-9a-z]+', 'i')) !== null;
+	return data.match(new RegExp('[0-9]+\:[a-z_-]+\:\/docker\/[0-9a-z]+', 'i')) !== null;
 }
+

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,10 @@ var assert = require('assert'),
 		'./lib/cmd': 'echo "10:net_prio:/docker/a9f22af020125424921a9dac4d8ab8681f7d7866da86d51e1fd97db857a51d1c\n9:perf_event:/docker/a9f22af020125424921a9dac4d8ab8681f7d7866da86d51e1fd97db857a51d1c"',
 		'./lib/hostname': function() { return 'a9f22af02012'; }
 	},
+	mockRenamedContainer = {
+		'./lib/cmd': 'echo "10:net_prio:/docker/a9f22af020125424921a9dac4d8ab8681f7d7866da86d51e1fd97db857a51d1c\n9:perf_event:/docker/a9f22af020125424921a9dac4d8ab8681f7d7866da86d51e1fd97db857a51d1c"',
+		'./lib/hostname': function() { return 'renamed-hostname'; }
+	},
 	mockNoContainer = {
 		'./lib/cmd': 'echo "10:net_prio:/\n9:perf_event:/"',
 		'./lib/hostname': function() { return 'a9f22af02012'; }
@@ -17,6 +21,11 @@ describe('containerized', function() {
 
 		it('should detect sync whether it runs inside a Docker container', function() {
 			var containerized = proxyquire('../index.js', mockContainer);
+			assert.equal(containerized(), true);
+		});
+
+		it('should detect sync whether it runs inside a renamed Docker container', function() {
+			var containerized = proxyquire('../index.js', mockRenamedContainer);
 			assert.equal(containerized(), true);
 		});
 
@@ -37,6 +46,16 @@ describe('containerized', function() {
 			});
 		});
 
+		it('should detect async whether it runs inside a renamed Docker container', function(done) {
+			var containerized = proxyquire('../index.js', mockRenamedContainer);
+
+			containerized(function(err, result) {
+				assert.equal(err, null);
+				assert.equal(result, true);
+				done();
+			});
+		});
+
 		it('should detect async whether it does not run inside a Docker container', function(done) {
 			var containerized = proxyquire('../index.js', mockNoContainer);
 
@@ -47,5 +66,6 @@ describe('containerized', function() {
 			});
 		});
 	}
-	
+
 });
+


### PR DESCRIPTION
If docker container hostname is overridden, the hostname in cgroups must be ignored.
Hostname can be overridden using [-h|--hostname[=HOSTNAME]] docker run option.
