### PR TITLE
Allow for optional `docker-ce/` prefix on docker cgroup identifier.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,5 +41,5 @@ module.exports = function(callback) {
 };
 
 function determine(data) {
-	return data.match(new RegExp('[0-9]+\:[a-z_-]+\:\/docker\/' + hostname + '[0-9a-z]+', 'i')) !== null;
+	return data.match(new RegExp('[0-9]+\:[a-z_-]+\:(\/docker-ce)?\/docker?\/' + hostname + '[0-9a-z]+', 'i')) !== null;
 }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(callback) {
 			// sync (node > 0.10.x)
 			try {
 				cgroups = child_process.execSync(cmd(), {
-    					stderr: 'ignore'
+    					stdio: ['pipe', 'pipe', 'ignore']
 				});
 			} catch (e) {
 				err = e;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,9 @@ module.exports = function(callback) {
 		if (child_process.execSync) {
 			// sync (node > 0.10.x)
 			try {
-				cgroups = child_process.execSync(cmd());
+				cgroups = child_process.execSync(cmd(), {
+    					stdio: 'ignore'
+				});
 			} catch (e) {
 				err = e;
 			}

--- a/index.js
+++ b/index.js
@@ -41,5 +41,5 @@ module.exports = function(callback) {
 };
 
 function determine(data) {
-	return data.match(new RegExp('[0-9]+\:[a-z_-]+\:(\/docker-ce)?\/docker?\/' + hostname + '[0-9a-z]+', 'i')) !== null;
+	return data.match(new RegExp('[0-9]+\:[a-z_-]+\:(\/docker-ce)?\/docker\/' + hostname + '[0-9a-z]+', 'i')) !== null;
 }

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function(callback) {
 			// sync (node > 0.10.x)
 			try {
 				cgroups = child_process.execSync(cmd(), {
-    					stdio: 'ignore'
+    					stderr: 'ignore'
 				});
 			} catch (e) {
 				err = e;


### PR DESCRIPTION
This should fix the issue where in docker-ce, containerization is not detected due to the `docker-ce/` prefix on the docker identifier in cgroup proc.

Fixes #8 

Also added a quick fix for #6

Fixes #6